### PR TITLE
Fix small typo on code sample on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ composer require spatie/laravel-db-loader
 ## Usage
 
 ``` php
-$db-loader = new Spatie\DbLoader();
-echo $db-loader->echoPhrase('Hello, Spatie!');
+$db->loader = new Spatie\DbLoader();
+echo $db->loader->echoPhrase('Hello, Spatie!');
 ```
 
 ## Changelog


### PR DESCRIPTION
Instead of using Object Operator (`->`) it was using single dash (`-`). Thus, adding `>` to have a proper code example.