### PR TITLE
Sanitize snapshot (file)name

### DIFF
--- a/src/SnapshotFactory.php
+++ b/src/SnapshotFactory.php
@@ -30,6 +30,7 @@ class SnapshotFactory
         $disk = $this->getDisk($diskName);
 
         $fileName = $snapshotName.'.sql';
+        $fileName = pathinfo($fileName, PATHINFO_BASENAME);
 
         event(new CreatingSnapshot(
             $fileName,


### PR DESCRIPTION
This PR sanitizes the given snapshot (file)name so it doesn't create subdirectories.

If the user enters a path as a snapshot name the snapshot is created at the given path on the disk.
It seems cleaner to have all snapshots in the root directory of the disk tho. This avoids confusion when having multiple snapshots with the same name in different subdirectories:

![screen shot 2017-03-23 at 11 08 11](https://cloud.githubusercontent.com/assets/6287961/24242787/27e31bfa-0fb9-11e7-869a-b58728135b77.png)

