### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "^5.4.16|~5.5.x-dev",
+        "illuminate/support": "^5.4.16|~5.5.x-dev|~5.5.x-dev",
         "league/flysystem": "^1.0.27",
         "spatie/db-dumper": "^2.7",
         "spatie/laravel-migrate-fresh": "^1.4.1",
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^0.9.8",
-        "orchestra/testbench": "^3.4.5|~3.5.x-dev",
+        "orchestra/testbench": "^3.4.5|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2"
     },
     "autoload": {
@@ -52,3 +52,4 @@
         }
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "^5.4.16",
+        "illuminate/support": "^5.4.16|~5.5.x-dev",
         "league/flysystem": "^1.0.27",
         "spatie/db-dumper": "^2.7",
         "spatie/laravel-migrate-fresh": "^1.4.1",
@@ -25,8 +25,8 @@
     },
     "require-dev": {
         "mockery/mockery": "^0.9.8",
-        "orchestra/testbench": "^3.4.5",
-        "phpunit/phpunit": "^5.7"
+        "orchestra/testbench": "^3.4.5|~3.5.x-dev",
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-db-snapshots/phpunit.xml.dist

........................                                          24 / 24 (100%)

Time: 7.14 seconds, Memory: 18.00MB

OK (24 tests, 42 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments