### PR TITLE
missing equal in connection parameter

### DIFF
--- a/src/Commands/Create.php
+++ b/src/Commands/Create.php
@@ -10,7 +10,7 @@ use Spatie\DbSnapshots\SnapshotFactory;
 
 class Create extends Command
 {
-    protected $signature = 'snapshot:create {name?} {--connection}';
+    protected $signature = 'snapshot:create {name?} {--connection=}';
 
     protected $description = 'Create a new snapshot.';
 


### PR DESCRIPTION
I believe this is a typo. without `=` no option can be passed