### PR TITLE
Use dashes in default snapshot name to support Windows

### DIFF
--- a/src/Commands/Create.php
+++ b/src/Commands/Create.php
@@ -22,7 +22,7 @@ class Create extends Command
             ?: config('db-snapshots.default_connection')
             ?? config('database.default');
 
-        $snapshotName = $this->argument('name') ?: Carbon::now()->format('Y-m-d H:i:s');
+        $snapshotName = $this->argument('name') ?: Carbon::now()->format('Y-m-d_H-i-s');
 
         $snapshot = app(SnapshotFactory::class)->create(
             $snapshotName,

--- a/tests/Commands/CreateTest.php
+++ b/tests/Commands/CreateTest.php
@@ -13,7 +13,7 @@ class CreateTest extends TestCase
     {
         Artisan::call('snapshot:create');
 
-        $fileName = Carbon::now()->format('Y-m-d H:i:s').'.sql';
+        $fileName = Carbon::now()->format('Y-m-d_H-i-s').'.sql';
 
         $this->assertFileOnDiskContains($fileName, 'CREATE TABLE "models"');
     }


### PR DESCRIPTION
We use Bash on Windows internally for development, which uses the Windows filesystem. Windows does not support `:` in filenames unfortunately 😢. Creating a snapshot with the default name results in the following error:

```
$ mysqldump --defaults-extra-file="/tmp/credentials" --skip-comments --extended-insert --result-file="2017-09-25 15:16:33.sql" database
mysqldump: Can't create/write to file '2017-09-25-15:16:33.sql' (Errcode: 22 - Invalid argument)
```

With this fix, success!

```
$ mysqldump --defaults-extra-file="/tmp/credentials" --skip-comments --extended-insert --result-file="2017-09-25_15-16-33.sql" database
```