### PR TITLE
Update to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "spatie/temporary-directory": "^1.1"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.8",
+        "mockery/mockery": "^1.0",
         "orchestra/testbench": "^3.4.5",
         "phpunit/phpunit": "^5.7"
     },


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).