### PR TITLE
Prevent Exception when trying to delete snapshots when there are none

### DIFF
--- a/src/Commands/Delete.php
+++ b/src/Commands/Delete.php
@@ -16,6 +16,14 @@ class Delete extends Command
 
     public function handle()
     {
+        $snapShots = app(SnapshotRepository::class)->getAll();
+
+        if (app(SnapshotRepository::class)->getAll()->isEmpty()) {
+            $this->warn('No snapshots found. Run `snapshot:create` to create snapshots.');
+
+            return;
+        }
+
         $name = $this->argument('name') ?: $this->askForSnapshotName();
 
         $snapshot = app(SnapshotRepository::class)->findByName($name);


### PR DESCRIPTION
If one calls the `snapshot:delete` command without providing a snapshot name and if there is no available snapshot, a `\LogicException` will be thrown when trying to build a list of choices.

![foo](https://user-images.githubusercontent.com/3188746/38925213-3ebbb222-42ff-11e8-89af-21041cfe084c.png)

This PR guards against the exception in a similar way to what is done within the [`snapshot:list`](https://github.com/spatie/laravel-db-snapshots/blob/bd4f67c6636e819b86fe3af40c9ce23417115265/src/Commands/ListSnapshots.php#L18-L24) and [`snapshot:load`](https://github.com/spatie/laravel-db-snapshots/blob/bd4f67c6636e819b86fe3af40c9ce23417115265/src/Commands/Load.php#L21-L27) commands.