### PR TITLE
Feature: support creating and loading gzip snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ return [
      * The directory where temporary files will be stored.
      */
     'temporary_directory_path' => storage_path('app/laravel-db-snapshots/temp'),
+
+    /*
+     * Create dump files that are gzipped
+     */
+    'compress' => false,
 ];
 ```
 
@@ -98,6 +103,13 @@ Giving your snapshot a name is optional. If you don't pass a name the current da
 ```bash
 # Creates a snapshot named something like `2017-03-17 14:31`
 php artisan snapshot:create
+```
+
+When creating snapshots, you can optionally create compressed snapshots.  To do this either pass the `--compress` option on the command line, or set the `db-snapshots.compress` configuration option to `true`:
+
+```bash
+# Creates a snapshot named my-compressed-dump.sql.gz
+php artisan snapshot:create my-compressed-dump --compress
 ```
 
 After you've made some changes to the database you can create another snapshot:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "mockery/mockery": "^0.9.8",
         "orchestra/testbench": "^3.4.10",
-        "phpunit/phpunit": "^6.2 || ^7.0"
+        "phpunit/phpunit": "^6.5 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.0",
         "illuminate/support": "^5.4.30",
         "league/flysystem": "^1.0.41",
-        "spatie/db-dumper": "^2.7",
+        "spatie/db-dumper": "^2.11",
         "spatie/laravel-migrate-fresh": "^1.4.1",
         "spatie/temporary-directory": "^1.1"
     },

--- a/config/db-snapshots.php
+++ b/config/db-snapshots.php
@@ -17,4 +17,9 @@ return [
      * The directory where temporary files will be stored.
      */
     'temporary_directory_path' => storage_path('app/laravel-db-snapshots/temp'),
+
+    /*
+     * Create dump files that are gzipped
+     */
+    'compress' => false,
 ];

--- a/src/Commands/Create.php
+++ b/src/Commands/Create.php
@@ -10,7 +10,7 @@ use Spatie\DbSnapshots\SnapshotFactory;
 
 class Create extends Command
 {
-    protected $signature = 'snapshot:create {name?} {--connection=}';
+    protected $signature = 'snapshot:create {name?} {--connection=} {--compress}';
 
     protected $description = 'Create a new snapshot.';
 
@@ -24,10 +24,13 @@ class Create extends Command
 
         $snapshotName = $this->argument('name') ?: Carbon::now()->format('Y-m-d_H-i-s');
 
+        $compress = $this->option('compress');
+
         $snapshot = app(SnapshotFactory::class)->create(
             $snapshotName,
             config('db-snapshots.disk'),
-            $connectionName
+            $connectionName,
+            $compress ?: null
         );
 
         $size = Format::humanReadableSize($snapshot->size());

--- a/src/Commands/Create.php
+++ b/src/Commands/Create.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\DbSnapshots\Commands;
 
-use DB;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Spatie\DbSnapshots\Helpers\Format;
@@ -24,13 +23,13 @@ class Create extends Command
 
         $snapshotName = $this->argument('name') ?: Carbon::now()->format('Y-m-d_H-i-s');
 
-        $compress = $this->option('compress');
+        $compress = $this->option('compress', null);
 
         $snapshot = app(SnapshotFactory::class)->create(
             $snapshotName,
             config('db-snapshots.disk'),
             $connectionName,
-            $compress ?: null
+            ($compress !== null) ? $compress : (bool) config('db-snapshots.compress', false)
         );
 
         $size = Format::humanReadableSize($snapshot->size());

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -23,7 +23,7 @@ class Snapshot
     public $name;
 
     /** @var string */
-    public $compressionExt = null;
+    public $compressionExtension = null;
 
     public function __construct(Disk $disk, string $fileName)
     {
@@ -34,7 +34,7 @@ class Snapshot
         $pathinfo = pathinfo($fileName);
 
         if ($pathinfo['extension'] === 'gz') {
-            $this->compressionExt = $pathinfo['extension'];
+            $this->compressionExtension = $pathinfo['extension'];
             $fileName = $pathinfo['filename'];
         }
 
@@ -53,7 +53,7 @@ class Snapshot
 
         $dbDumpContents = $this->disk->get($this->fileName);
 
-        if ($this->compressionExt === 'gz') {
+        if ($this->compressionExtension === 'gz') {
             $dbDumpContents = gzdecode($dbDumpContents);
         }
 

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -22,11 +22,21 @@ class Snapshot
     /** @var string */
     public $name;
 
+    /** @var string */
+    public $compressionExt = null;
+
     public function __construct(Disk $disk, string $fileName)
     {
         $this->disk = $disk;
 
         $this->fileName = $fileName;
+
+        $pathinfo = pathinfo($fileName);
+
+        if ($pathinfo['extension'] === 'gz') {
+            $this->compressionExt = $pathinfo['extension'];
+            $fileName = $pathinfo['filename'];
+        }
 
         $this->name = pathinfo($fileName, PATHINFO_FILENAME);
     }
@@ -42,6 +52,10 @@ class Snapshot
         $this->dropAllCurrentTables();
 
         $dbDumpContents = $this->disk->get($this->fileName);
+
+        if ($this->compressionExt === 'gz') {
+            $dbDumpContents = gzdecode($dbDumpContents);
+        }
 
         DB::connection($connectionName)->unprepared($dbDumpContents);
 

--- a/src/SnapshotFactory.php
+++ b/src/SnapshotFactory.php
@@ -26,14 +26,12 @@ class SnapshotFactory
         $this->filesystemFactory = $filesystemFactory;
     }
 
-    public function create(string $snapshotName, string $diskName, string $connectionName, bool $compress = null): Snapshot
+    public function create(string $snapshotName, string $diskName, string $connectionName, bool $compress = false): Snapshot
     {
         $disk = $this->getDisk($diskName);
 
         $fileName = $snapshotName.'.sql';
         $fileName = pathinfo($fileName, PATHINFO_BASENAME);
-
-        $compress = ($compress === true) ?: (bool) config('db-snapshots.compress', false);
 
         if ($compress) {
             $fileName .= '.gz';

--- a/src/SnapshotFactory.php
+++ b/src/SnapshotFactory.php
@@ -2,11 +2,11 @@
 
 namespace Spatie\DbSnapshots;
 
-use Spatie\DbDumper\Compressors\GzipCompressor;
 use Spatie\DbDumper\DbDumper;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Spatie\DbSnapshots\Events\CreatedSnapshot;
+use Spatie\DbDumper\Compressors\GzipCompressor;
 use Spatie\DbSnapshots\Events\CreatingSnapshot;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Spatie\DbSnapshots\Exceptions\CannotCreateDisk;

--- a/src/SnapshotFactory.php
+++ b/src/SnapshotFactory.php
@@ -68,7 +68,7 @@ class SnapshotFactory
         return $factory::createForConnection($connectionName);
     }
 
-    protected function createDump(string $connectionName, string $fileName, FilesystemAdapter $disk, bool $compress)
+    protected function createDump(string $connectionName, string $fileName, FilesystemAdapter $disk, bool $compress = false)
     {
         $directory = (new TemporaryDirectory(config('db-snapshots.temporary_directory_path')))->create();
 

--- a/src/SnapshotRepository.php
+++ b/src/SnapshotRepository.php
@@ -19,6 +19,12 @@ class SnapshotRepository
     {
         return collect($this->disk->allFiles())
             ->filter(function (string $fileName) {
+                $pathinfo = pathinfo($fileName);
+
+                if ($pathinfo['extension'] === 'gz') {
+                    $fileName = $pathinfo['filename'];
+                }
+
                 return pathinfo($fileName, PATHINFO_EXTENSION) === 'sql';
             })
             ->map(function (string $fileName) {

--- a/tests/Commands/CreateTest.php
+++ b/tests/Commands/CreateTest.php
@@ -15,7 +15,7 @@ class CreateTest extends TestCase
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s').'.sql';
 
-        $this->assertFileOnDiskContains($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/', true);
+        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
     }
 
     /** @test */
@@ -23,7 +23,7 @@ class CreateTest extends TestCase
     {
         Artisan::call('snapshot:create', ['name' => 'test']);
 
-        $this->assertFileOnDiskContains('test.sql', '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/', true);
+        $this->assertFileOnDiskPassesRegex('test.sql', '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
     }
 
     /** @test */

--- a/tests/Commands/CreateTest.php
+++ b/tests/Commands/CreateTest.php
@@ -15,7 +15,7 @@ class CreateTest extends TestCase
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s').'.sql';
 
-        $this->assertFileOnDiskContains($fileName, 'CREATE TABLE "models"');
+        $this->assertFileOnDiskContains($fileName, 'CREATE TABLE IF NOT EXISTS "models"');
     }
 
     /** @test */
@@ -23,6 +23,16 @@ class CreateTest extends TestCase
     {
         Artisan::call('snapshot:create', ['name' => 'test']);
 
-        $this->assertFileOnDiskContains('test.sql', 'CREATE TABLE "models"');
+        $this->assertFileOnDiskContains('test.sql', 'CREATE TABLE IF NOT EXISTS "models"');
+    }
+
+    /** @test */
+    public function it_can_create_a_compressed_snapshot()
+    {
+        Artisan::call('snapshot:create', ['--compress' => true]);
+
+        $fileName = Carbon::now()->format('Y-m-d_H-i-s').'.sql.gz';
+
+        $this->assertFileOnDiskContains($fileName, 'CREATE TABLE IF NOT EXISTS "models"', true);
     }
 }

--- a/tests/Commands/CreateTest.php
+++ b/tests/Commands/CreateTest.php
@@ -15,7 +15,7 @@ class CreateTest extends TestCase
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s').'.sql';
 
-        $this->assertFileOnDiskContains($fileName, 'CREATE TABLE IF NOT EXISTS "models"');
+        $this->assertFileOnDiskContains($fileName, 'CREATE TABLE "models"');
     }
 
     /** @test */
@@ -23,7 +23,7 @@ class CreateTest extends TestCase
     {
         Artisan::call('snapshot:create', ['name' => 'test']);
 
-        $this->assertFileOnDiskContains('test.sql', 'CREATE TABLE IF NOT EXISTS "models"');
+        $this->assertFileOnDiskContains('test.sql', 'CREATE TABLE "models"');
     }
 
     /** @test */
@@ -33,6 +33,6 @@ class CreateTest extends TestCase
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s').'.sql.gz';
 
-        $this->assertFileOnDiskContains($fileName, 'CREATE TABLE IF NOT EXISTS "models"', true);
+        $this->assertFileOnDiskContains($fileName, 'CREATE TABLE "models"', true);
     }
 }

--- a/tests/Commands/CreateTest.php
+++ b/tests/Commands/CreateTest.php
@@ -15,7 +15,7 @@ class CreateTest extends TestCase
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s').'.sql';
 
-        $this->assertFileOnDiskContains($fileName, 'CREATE TABLE "models"');
+        $this->assertFileOnDiskContains($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/', true);
     }
 
     /** @test */
@@ -23,7 +23,7 @@ class CreateTest extends TestCase
     {
         Artisan::call('snapshot:create', ['name' => 'test']);
 
-        $this->assertFileOnDiskContains('test.sql', 'CREATE TABLE "models"');
+        $this->assertFileOnDiskContains('test.sql', '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/', true);
     }
 
     /** @test */
@@ -33,6 +33,8 @@ class CreateTest extends TestCase
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s').'.sql.gz';
 
-        $this->assertFileOnDiskContains($fileName, 'CREATE TABLE "models"', true);
+        $this->disk->assertExists($fileName);
+
+        $this->assertNotEmpty(gzdecode($this->disk->get($fileName)));
     }
 }

--- a/tests/Commands/LoadTest.php
+++ b/tests/Commands/LoadTest.php
@@ -58,6 +58,16 @@ class LoadTest extends TestCase
         $this->assertSnapshotLoaded('snapshot2');
     }
 
+    /** @test */
+    public function it_can_load_a_compressed_snapshot()
+    {
+        $this->assertSnapshotNotLoaded('snapshot4');
+
+        Artisan::call('snapshot:load', ['name' => 'snapshot4']);
+
+        $this->assertSnapshotLoaded('snapshot4');
+    }
+
     protected function assertSnapshotLoaded($snapshotName)
     {
         $this->assertEquals(

--- a/tests/SnapshotRepositoryTest.php
+++ b/tests/SnapshotRepositoryTest.php
@@ -22,7 +22,7 @@ class SnapshotRepositoryTest extends TestCase
     {
         $snapshots = $this->repository->getAll();
 
-        $this->assertCount(3, $snapshots);
+        $this->assertCount(4, $snapshots);
 
         $this->assertInstanceOf(Snapshot::class, $snapshots->first());
     }
@@ -32,6 +32,18 @@ class SnapshotRepositoryTest extends TestCase
     {
         $this->assertInstanceOf(Snapshot::class, $this->repository->findByName('snapshot2'));
 
-        $this->assertNull($this->repository->findByName('snapshot4'));
+        $this->assertNull($this->repository->findByName('snapshot5'));
+    }
+
+    /** @test */
+    public function it_can_find_gz_compressed_snapshots()
+    {
+        $snapshot = $this->repository->findByName('snapshot4');
+
+        $this->assertInstanceOf(Snapshot::class, $snapshot);
+
+        $this->assertEquals('gz', $snapshot->compressionExt);
+
+        $this->assertNull($this->repository->findByName('snapshot5'));
     }
 }

--- a/tests/SnapshotRepositoryTest.php
+++ b/tests/SnapshotRepositoryTest.php
@@ -42,7 +42,7 @@ class SnapshotRepositoryTest extends TestCase
 
         $this->assertInstanceOf(Snapshot::class, $snapshot);
 
-        $this->assertEquals('gz', $snapshot->compressionExt);
+        $this->assertEquals('gz', $snapshot->compressionExtension);
 
         $this->assertNull($this->repository->findByName('snapshot5'));
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,11 +56,15 @@ abstract class TestCase extends Orchestra
         ]);
     }
 
-    protected function assertFileOnDiskContains($fileName, $needle)
+    protected function assertFileOnDiskContains($fileName, $needle, $uncompress = false)
     {
         $this->disk->assertExists($fileName);
 
         $contents = $this->disk->get($fileName);
+
+        if ($uncompress) {
+            $contents = gzdecode($contents);
+        }
 
         $this->assertContains($needle, $contents);
     }
@@ -101,6 +105,8 @@ abstract class TestCase extends Orchestra
         foreach (range(1, 3) as $i) {
             $this->disk->put("snapshot{$i}.sql", $this->getSnapshotContent("snapshot{$i}"));
         }
+
+        $this->disk->put("snapshot4.sql.gz", gzencode($this->getSnapshotContent('snapshot4')));
 
         $this->disk->put('otherfile.txt', 'not a snapshot');
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,17 +56,13 @@ abstract class TestCase extends Orchestra
         ]);
     }
 
-    protected function assertFileOnDiskContains($fileName, $needle, $uncompress = false)
+    protected function assertFileOnDiskContains($fileName, $needle, bool $isRegex = false)
     {
         $this->disk->assertExists($fileName);
 
         $contents = $this->disk->get($fileName);
 
-        if ($uncompress) {
-            $contents = gzdecode($contents);
-        }
-
-        $this->assertContains($needle, $contents);
+        ($isRegex) ? $this->assertRegExp($needle, $contents) : $this->assertContains($needle, $contents);
     }
 
     protected function setupDatabase()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -106,7 +106,7 @@ abstract class TestCase extends Orchestra
             $this->disk->put("snapshot{$i}.sql", $this->getSnapshotContent("snapshot{$i}"));
         }
 
-        $this->disk->put("snapshot4.sql.gz", gzencode($this->getSnapshotContent('snapshot4')));
+        $this->disk->put('snapshot4.sql.gz', gzencode($this->getSnapshotContent('snapshot4')));
 
         $this->disk->put('otherfile.txt', 'not a snapshot');
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,13 +56,13 @@ abstract class TestCase extends Orchestra
         ]);
     }
 
-    protected function assertFileOnDiskContains($fileName, $needle, bool $isRegex = false)
+    protected function assertFileOnDiskPassesRegex($fileName, $needle)
     {
         $this->disk->assertExists($fileName);
 
         $contents = $this->disk->get($fileName);
 
-        ($isRegex) ? $this->assertRegExp($needle, $contents) : $this->assertContains($needle, $contents);
+        $this->assertRegExp($needle, $contents);
     }
 
     protected function setupDatabase()


### PR DESCRIPTION
This adds support to `laravel-db-snapshots` to make it support creating gzipped snapshots either by passing the command line option or configuring it via the config file.  `spatie/db-dumper` already supports this feature, and this allows the snapshot tool to expose that feature.  Fairly straight forward cli usage:

```console
$ artisan snapshot:create mysnap --compress
$ artisan snapshot:load mysnap
```

Note: on my machine with the dependencies listed for this project, dumping sqlite databases appears to include `IF NOT EXISTS` which the current tests do not account for. I did not research where the change happened to make the current tests fail, but I did fix it none-the-less (see `tests/Commands/CreateTest.php`).

This is actually 1 part of a 2 part feature, I would like to be able to (at least with mysql) be able to load snapshots with an external tool (like the `mysql` cli utility) similar to how dumps are produced with `mysqldump`. I was considering whether to add that feature to `laravel-db-snapshots` (because it has to do with the loading of files) or whether it should be a feature of `db-dumper` (because there is a certain level of parity in how that tool deals with calling external processes, like `mysqldump`). Are you interested in this? what would be your thoughts?