### PR TITLE
Fix compression option from config not being respected

### DIFF
--- a/src/Commands/Create.php
+++ b/src/Commands/Create.php
@@ -23,13 +23,13 @@ class Create extends Command
 
         $snapshotName = $this->argument('name') ?: Carbon::now()->format('Y-m-d_H-i-s');
 
-        $compress = $this->option('compress', null);
+        $compress = $this->option('compress') || config('db-snapshots.compress', false);
 
         $snapshot = app(SnapshotFactory::class)->create(
             $snapshotName,
             config('db-snapshots.disk'),
             $connectionName,
-            ($compress !== null) ? $compress : (bool) config('db-snapshots.compress', false)
+            $compress
         );
 
         $size = Format::humanReadableSize($snapshot->size());

--- a/tests/Commands/CreateTest.php
+++ b/tests/Commands/CreateTest.php
@@ -27,9 +27,23 @@ class CreateTest extends TestCase
     }
 
     /** @test */
-    public function it_can_create_a_compressed_snapshot()
+    public function it_can_create_a_compressed_snapshot_from_cli_param()
     {
         Artisan::call('snapshot:create', ['--compress' => true]);
+
+        $fileName = Carbon::now()->format('Y-m-d_H-i-s').'.sql.gz';
+
+        $this->disk->assertExists($fileName);
+
+        $this->assertNotEmpty(gzdecode($this->disk->get($fileName)));
+    }
+
+    /** @test */
+    public function it_can_create_a_compressed_snapshot_from_config()
+    {
+        $this->app['config']->set('db-snapshots.compress', true);
+
+        Artisan::call('snapshot:create');
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s').'.sql.gz';
 


### PR DESCRIPTION
The current implementation [passes a second parameter into `option`](https://github.com/spatie/laravel-db-snapshots/blob/master/src/Commands/Create.php#L26) seemingly as a default to fallback to if no option is passed, but this is [not a feature of the `option` method](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Console/Command.php#L304).


This call returns `false` if the `--compress` option is not present, which then causes the ternary to always pass in `false` instead of falling back to the value in the config as it strictly checks against `null`