### PR TITLE
Load command does not work in production env

### DIFF
--- a/src/Commands/Load.php
+++ b/src/Commands/Load.php
@@ -12,7 +12,7 @@ class Load extends Command
     use AsksForSnapshotName;
     use ConfirmableTrait;
 
-    protected $signature = 'snapshot:load {name?} {--connection=} --disk';
+    protected $signature = 'snapshot:load {name?} {--connection=} {--force} --disk';
 
     protected $description = 'Load up a snapshot.';
 


### PR DESCRIPTION
I found an issue where the load command will not work when APP_ENV is set to 'production'. As the command uses the ConfirmableTrait, it must also define a "--force" option in the command signature. Without the force option, the command outputs an error saying "The force option does not exist".

Simply adding the option to the signature fixes both the confirmation dialog AND the --force option usage.

Thanks!