### PR TITLE
Fixes an obscure but repeatable issue relating to rmdir failing

### DIFF
--- a/src/SnapshotFactory.php
+++ b/src/SnapshotFactory.php
@@ -90,6 +90,8 @@ class SnapshotFactory
             fclose($file);
         }
 
+        gc_collect_cycles();
+
         $directory->delete();
     }
 }


### PR DESCRIPTION
This issue has been documented several times in other respositories but was never actually fixed. Most notably here:

https://github.com/spatie/laravel-backup/issues/393

The problem may need to be fixed in multiple repositories.

Essentially, when calling the TemporaryDirectory->delete() method, if you also call an fclose() before php has had adequate time to complete its garbage collection cycles, the resources that were fclosed only appear to be fclosed, and are in fact still reserved by php.

By forcing a php garbage collection cycle using gc_collect_cycles() we can ensure that the rmdir function called in spatie/temporary-directory/TemporaryDirectory does not fail due to files still being reserved in memory (in the garbage due to fclose, but reserved nonetheless).

Replicating this issue is extremely difficult because of the number of environmental and system factors that go in to play. However, there have been documented cases, and I myself ran into the issue today. Thus the PR.

Cheers!