### PR TITLE
Add command to cleanup old snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ php artisan snapshot:load my-first-dump
 
 # List all snapshots
 php artisan snapshot:list
+
+# Remove old snapshots. Keeping only the most recent
+php artisan snapshot:cleanup --keep=2
 ```
 
 This package supports MySQL, PostgreSQL and SQLite.
@@ -133,6 +136,12 @@ A dump can be deleted with:
 
 ```bash
 php artisan snapshot:delete my-first-dump
+```
+
+To remove all backups except the most recent 2
+
+```bash
+php artisan snapshot:cleanup --keep=2
 ```
 
 ## Events

--- a/src/Commands/Cleanup.php
+++ b/src/Commands/Cleanup.php
@@ -7,24 +7,24 @@ use Spatie\DbSnapshots\SnapshotRepository;
 
 class Cleanup extends Command
 {
-	protected $signature = 'snapshot:cleanup {--keep=}';
+    protected $signature = 'snapshot:cleanup {--keep=}';
 
-	protected $description = 'Specify how many snapshots to keep and delete the rest';
+    protected $description = 'Specify how many snapshots to keep and delete the rest';
 
-	public function handle()
-	{
-		$snapshots = app(SnapshotRepository::class)->getAll();
+    public function handle()
+    {
+        $snapshots = app(SnapshotRepository::class)->getAll();
 
-		$keep = $this->option('keep');
+        $keep = $this->option('keep');
 
-		if (!$this->option('keep')) {
-			$this->warn('No value for option --keep.');
+        if (!$this->option('keep')) {
+            $this->warn('No value for option --keep.');
 
-			return;
-		}
+            return;
+        }
 
-		$snapshots->splice($keep)->each(function ($snapshot) {
-			$snapshot->delete();
-		});
-	}
+        $snapshots->splice($keep)->each(function ($snapshot) {
+            $snapshot->delete();
+        });
+    }
 }

--- a/src/Commands/Cleanup.php
+++ b/src/Commands/Cleanup.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\DbSnapshots\Commands;
+
+use Illuminate\Console\Command;
+use Spatie\DbSnapshots\SnapshotRepository;
+
+class Cleanup extends Command
+{
+	protected $signature = 'snapshot:cleanup {--keep=}';
+
+	protected $description = 'Specify how many snapshots to keep and delete the rest';
+
+	public function handle()
+	{
+		$snapshots = app(SnapshotRepository::class)->getAll();
+
+		$keep = $this->option('keep');
+
+		if (!$this->option('keep')) {
+			$this->warn('No value for option --keep.');
+
+			return;
+		}
+
+		$snapshots->splice($keep)->each(function ($snapshot) {
+			$snapshot->delete();
+		});
+	}
+}

--- a/src/Commands/Cleanup.php
+++ b/src/Commands/Cleanup.php
@@ -17,7 +17,7 @@ class Cleanup extends Command
 
         $keep = $this->option('keep');
 
-        if (!$this->option('keep')) {
+        if (! $this->option('keep')) {
             $this->warn('No value for option --keep.');
 
             return;

--- a/src/DbSnapshotsServiceProvider.php
+++ b/src/DbSnapshotsServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\ServiceProvider;
 use Spatie\DbSnapshots\Commands\Create;
 use Spatie\DbSnapshots\Commands\Delete;
 use Illuminate\Contracts\Filesystem\Factory;
+use Spatie\DbSnapshots\Commands\Cleanup;
 use Spatie\DbSnapshots\Commands\ListSnapshots;
 
 class DbSnapshotsServiceProvider extends ServiceProvider
@@ -34,12 +35,14 @@ class DbSnapshotsServiceProvider extends ServiceProvider
         $this->app->bind('command.snapshot:load', Load::class);
         $this->app->bind('command.snapshot:delete', Delete::class);
         $this->app->bind('command.snapshot:list', ListSnapshots::class);
+        $this->app->bind('command.snapshot:cleanup', Cleanup::class);
 
         $this->commands([
             'command.snapshot:create',
             'command.snapshot:load',
             'command.snapshot:delete',
             'command.snapshot:list',
+            'command.snapshot:cleanup',
         ]);
     }
 

--- a/src/DbSnapshotsServiceProvider.php
+++ b/src/DbSnapshotsServiceProvider.php
@@ -6,8 +6,8 @@ use Spatie\DbSnapshots\Commands\Load;
 use Illuminate\Support\ServiceProvider;
 use Spatie\DbSnapshots\Commands\Create;
 use Spatie\DbSnapshots\Commands\Delete;
-use Illuminate\Contracts\Filesystem\Factory;
 use Spatie\DbSnapshots\Commands\Cleanup;
+use Illuminate\Contracts\Filesystem\Factory;
 use Spatie\DbSnapshots\Commands\ListSnapshots;
 
 class DbSnapshotsServiceProvider extends ServiceProvider

--- a/tests/Commands/CleanupTest.php
+++ b/tests/Commands/CleanupTest.php
@@ -2,29 +2,27 @@
 
 namespace Spatie\DbSnapshots\Commands\Test;
 
-use Mockery as m;
 use Spatie\DbSnapshots\Test\TestCase;
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\Storage;
 
 class CleanupTest extends TestCase
 {
-    /** @test */
-    public function it_can_delete_old_snapshots_keeping_the_desired_number_of_snapshots()
-    {
-        // Add sleep to make sure files do not have the same modified time.
-        // They may not sort properly if all have the same timestamp.
-        $this->clearDisk();
-       
-        $this->disk->put("snapshot1.sql", 'new content');
-        
-        sleep(1);
-        
-        $this->disk->put("snapshot2.sql", 'new content');
-        
-        Artisan::call('snapshot:cleanup', ['--keep' => 1]);
+	/** @test */
+	public function it_can_delete_old_snapshots_keeping_the_desired_number_of_snapshots()
+	{
+		// Add sleep to make sure files do not have the same modified time.
+		// They may not sort properly if all have the same timestamp.
+		$this->clearDisk();
 
-        $this->disk->assertMissing('snapshot1.sql');
-        $this->disk->assertExists('snapshot2.sql');
-    }
+		$this->disk->put('snapshot1.sql', 'new content');
+
+		sleep(1);
+
+		$this->disk->put('snapshot2.sql', 'new content');
+
+		Artisan::call('snapshot:cleanup', ['--keep' => 1]);
+
+		$this->disk->assertMissing('snapshot1.sql');
+		$this->disk->assertExists('snapshot2.sql');
+	}
 }

--- a/tests/Commands/CleanupTest.php
+++ b/tests/Commands/CleanupTest.php
@@ -7,22 +7,22 @@ use Illuminate\Support\Facades\Artisan;
 
 class CleanupTest extends TestCase
 {
-	/** @test */
-	public function it_can_delete_old_snapshots_keeping_the_desired_number_of_snapshots()
-	{
-		// Add sleep to make sure files do not have the same modified time.
-		// They may not sort properly if all have the same timestamp.
-		$this->clearDisk();
+    /** @test */
+    public function it_can_delete_old_snapshots_keeping_the_desired_number_of_snapshots()
+    {
+        // Add sleep to make sure files do not have the same modified time.
+        // They may not sort properly if all have the same timestamp.
+        $this->clearDisk();
 
-		$this->disk->put('snapshot1.sql', 'new content');
+        $this->disk->put('snapshot1.sql', 'new content');
 
-		sleep(1);
+        sleep(1);
 
-		$this->disk->put('snapshot2.sql', 'new content');
+        $this->disk->put('snapshot2.sql', 'new content');
 
-		Artisan::call('snapshot:cleanup', ['--keep' => 1]);
+        Artisan::call('snapshot:cleanup', ['--keep' => 1]);
 
-		$this->disk->assertMissing('snapshot1.sql');
-		$this->disk->assertExists('snapshot2.sql');
-	}
+        $this->disk->assertMissing('snapshot1.sql');
+        $this->disk->assertExists('snapshot2.sql');
+    }
 }

--- a/tests/Commands/CleanupTest.php
+++ b/tests/Commands/CleanupTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\DbSnapshots\Commands\Test;
+
+use Mockery as m;
+use Spatie\DbSnapshots\Test\TestCase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
+
+class CleanupTest extends TestCase
+{
+    /** @test */
+    public function it_can_delete_old_snapshots_keeping_the_desired_number_of_snapshots()
+    {
+        // Add sleep to make sure files do not have the same modified time.
+        // They may not sort properly if all have the same timestamp.
+        $this->clearDisk();
+       
+        $this->disk->put("snapshot1.sql", 'new content');
+        
+        sleep(1);
+        
+        $this->disk->put("snapshot2.sql", 'new content');
+        
+        Artisan::call('snapshot:cleanup', ['--keep' => 1]);
+
+        $this->disk->assertMissing('snapshot1.sql');
+        $this->disk->assertExists('snapshot2.sql');
+    }
+}


### PR DESCRIPTION
This adds a command to cleanup old snapshots. It accepts a --keep option which specifies how many snapshots to keep and deletes the rest. 

Example: I have an app that is scheduled to create a snapshot twice a day. This command could run to keep the snapshot directory from having too many snapshots.