### PR TITLE
Add a --latest option to the snapshots:load method to load the latest available snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ php artisan snapshot:create my-second-dump
 # Load up the first dump
 php artisan snapshot:load my-first-dump
 
+# Load up the latest dump
+php artisan snapshot:load --latest
+
 # List all snapshots
 php artisan snapshot:list
 

--- a/src/Commands/Load.php
+++ b/src/Commands/Load.php
@@ -30,14 +30,12 @@ class Load extends Command
             return;
         }
 
-        $use_latest_snapshot = $this->option('latest')?: false;
+        $use_latest_snapshot = $this->option('latest') ?: false;
 
         if ($use_latest_snapshot) {
             $name = $snapShots->last()->name;
-
         } else {
             $name = $this->argument('name') ?: $this->askForSnapshotName();
-
         }
 
         $snapshot = app(SnapshotRepository::class)->findByName($name);

--- a/src/Commands/Load.php
+++ b/src/Commands/Load.php
@@ -32,12 +32,10 @@ class Load extends Command
 
         $useLatestSnapshot = $this->option('latest') ?: false;
 
-        if ($useLatestSnapshot) {
-            $name = $snapShots->last()->name;
-        } else {
-            $name = $this->argument('name') ?: $this->askForSnapshotName();
-        }
-
+        $name = $useLatestSnapshot
+            ? $snapShots->last()->name;
+            : $this->argument('name') ?: $this->askForSnapshotName();
+   
         $snapshot = app(SnapshotRepository::class)->findByName($name);
 
         if (! $snapshot) {

--- a/src/Commands/Load.php
+++ b/src/Commands/Load.php
@@ -12,7 +12,7 @@ class Load extends Command
     use AsksForSnapshotName;
     use ConfirmableTrait;
 
-    protected $signature = 'snapshot:load {name?} {--connection=} {--force} --disk';
+    protected $signature = 'snapshot:load {name?} {--connection=} {--force} --disk {--latest}';
 
     protected $description = 'Load up a snapshot.';
 
@@ -30,7 +30,15 @@ class Load extends Command
             return;
         }
 
-        $name = $this->argument('name') ?: $this->askForSnapshotName();
+        $use_latest_snapshot = $this->option('latest')?: false;
+
+        if ($use_latest_snapshot) {
+            $name = $snapShots->last()->name;
+
+        } else {
+            $name = $this->argument('name') ?: $this->askForSnapshotName();
+
+        }
 
         $snapshot = app(SnapshotRepository::class)->findByName($name);
 

--- a/src/Commands/Load.php
+++ b/src/Commands/Load.php
@@ -33,7 +33,7 @@ class Load extends Command
         $useLatestSnapshot = $this->option('latest') ?: false;
 
         $name = $useLatestSnapshot
-            ? $snapShots->last()->name;
+            ? $snapShots->last()->name
             : $this->argument('name') ?: $this->askForSnapshotName();
    
         $snapshot = app(SnapshotRepository::class)->findByName($name);

--- a/src/Commands/Load.php
+++ b/src/Commands/Load.php
@@ -30,9 +30,9 @@ class Load extends Command
             return;
         }
 
-        $use_latest_snapshot = $this->option('latest') ?: false;
+        $useLatestSnapshot = $this->option('latest') ?: false;
 
-        if ($use_latest_snapshot) {
+        if ($useLatestSnapshot) {
             $name = $snapShots->last()->name;
         } else {
             $name = $this->argument('name') ?: $this->askForSnapshotName();

--- a/tests/Commands/LoadTest.php
+++ b/tests/Commands/LoadTest.php
@@ -49,6 +49,16 @@ class LoadTest extends TestCase
     }
 
     /** @test */
+    public function it_can_load_the_latest_snapshot()
+    {
+        $this->assertSnapshotNotLoaded('snapshot4');
+
+        Artisan::call('snapshot:load', ['--latest' => true]);
+
+        $this->assertSnapshotLoaded('snapshot4');
+    }
+
+    /** @test */
     public function it_can_load_a_snapshot_with_connection_option()
     {
         $this->assertSnapshotNotLoaded('snapshot2');


### PR DESCRIPTION
I took this approach instead of the initial suggestion in https://github.com/spatie/laravel-db-snapshots/issues/94 as the intent of the option is much clearer