### PR TITLE
Fix deprecated implode usage

### DIFF
--- a/src/Exceptions/CannotCreateDisk.php
+++ b/src/Exceptions/CannotCreateDisk.php
@@ -14,7 +14,7 @@ class CannotCreateDisk extends Exception
             return new static("Cannot create a disk `{$diskName}`. There are no disks set up.");
         }
 
-        $existingDiskNames = implode(array_keys($disks), ', ');
+        $existingDiskNames = implode(', ', array_keys($disks));
 
         return new static("Cannot create a disk `{$diskName}`. Known disknames are {$existingDiskNames}.");
     }


### PR DESCRIPTION
This closes https://github.com/spatie/laravel-db-snapshots/issues/88

Since PHP 7.4, passing in the glue string as the second argument is deprecated and will throw an error. [Ref](https://www.php.net/manual/en/migration74.deprecated.php)