### PR TITLE
Fix getting latest snapshot and update test

### DIFF
--- a/src/Commands/Load.php
+++ b/src/Commands/Load.php
@@ -33,7 +33,7 @@ class Load extends Command
         $useLatestSnapshot = $this->option('latest') ?: false;
 
         $name = $useLatestSnapshot
-            ? $snapShots->last()->name
+            ? $snapShots->first()->name
             : ($this->argument('name') ?: $this->askForSnapshotName());
 
         $snapshot = app(SnapshotRepository::class)->findByName($name);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -101,6 +101,7 @@ abstract class TestCase extends Orchestra
             $this->disk->put("snapshot{$i}.sql", $this->getSnapshotContent("snapshot{$i}"));
         }
 
+        // Make sure the next snapshot is created at least 1 second after the ones that created earlier.
         sleep(1);
 
         $this->disk->put('snapshot4.sql.gz', gzencode($this->getSnapshotContent('snapshot4')));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -101,6 +101,8 @@ abstract class TestCase extends Orchestra
             $this->disk->put("snapshot{$i}.sql", $this->getSnapshotContent("snapshot{$i}"));
         }
 
+        sleep(1);
+
         $this->disk->put('snapshot4.sql.gz', gzencode($this->getSnapshotContent('snapshot4')));
 
         $this->disk->put('otherfile.txt', 'not a snapshot');


### PR DESCRIPTION
I already created a PR but is was rejected because failing tests. Unfortunately the original test seems to be wrong. The autogenerated snapshots are created nano seconds after each other so the createdAt() function returns always the same timestamp. To fix this I had to add a one second gap before the latest snapshot is created, this slows the tests a bit.