### PR TITLE
Fix cleaning up all snapshots

### DIFF
--- a/src/Commands/Cleanup.php
+++ b/src/Commands/Cleanup.php
@@ -17,7 +17,7 @@ class Cleanup extends Command
 
         $keep = $this->option('keep');
 
-        if (!$keep && $keep !== '0') {
+        if (! $keep && $keep !== '0') {
             $this->warn('No value for option --keep.');
 
             return;

--- a/src/Commands/Cleanup.php
+++ b/src/Commands/Cleanup.php
@@ -17,7 +17,7 @@ class Cleanup extends Command
 
         $keep = $this->option('keep');
 
-        if (! $this->option('keep')) {
+        if (!$keep && $keep !== '0') {
             $this->warn('No value for option --keep.');
 
             return;

--- a/tests/Commands/CleanupTest.php
+++ b/tests/Commands/CleanupTest.php
@@ -37,4 +37,17 @@ class CleanupTest extends TestCase
 
         $this->disk->assertMissing('snapshot.sql');
     }
+
+    /** @test */
+    public function it_warns_if_keep_is_not_specified()
+    {
+        $this->clearDisk();
+
+        $this->disk->put('snapshot.sql', 'new content');
+
+        Artisan::call('snapshot:cleanup');
+
+        $this->disk->assertExists('snapshot.sql');
+        $this->seeInConsoleOutput('No value for option --keep.');
+    }
 }

--- a/tests/Commands/CleanupTest.php
+++ b/tests/Commands/CleanupTest.php
@@ -25,4 +25,16 @@ class CleanupTest extends TestCase
         $this->disk->assertMissing('snapshot1.sql');
         $this->disk->assertExists('snapshot2.sql');
     }
+
+    /** @test */
+    public function it_can_delete_all_snapshots_if_keep_is_zero()
+    {
+        $this->clearDisk();
+
+        $this->disk->put('snapshot.sql', 'new content');
+
+        Artisan::call('snapshot:cleanup --keep=0');
+
+        $this->disk->assertMissing('snapshot.sql');
+    }
 }


### PR DESCRIPTION
In #79, support for cleaning up old snapshots was added, keeping a specified number of snapshots. I am using this package for E2E tests, and want to clean up ALL snapshots at once. However, a bug in the logic considers `--keep=0` to be the same as the `--keep` option being absent. This PR fixes that and adds more tests for the behaviour of the keep flag.