### PR TITLE
Add PHP 8-only Support (v2)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,3 @@
-; This file is for unifying the coding style for different editors and IDEs.
-; More information at http://editorconfig.org
-
 root = true
 
 [*]
@@ -13,3 +10,6 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,10 +2,13 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
+/.github            export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
-/.travis.yml        export-ignore
 /phpunit.xml.dist   export-ignore
-/.scrutinizer.yml   export-ignore
 /tests              export-ignore
 /.editorconfig      export-ignore
+/.php_cs.dist       export-ignore
+/psalm.xml          export-ignore
+/psalm.xml.dist     export-ignore
+/testbench.yaml     export-ignore

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: spatie
 custom: https://spatie.be/open-source/support-us

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+If you discover any security related issues, please email freek@spatie.be instead of using the issue tracker.

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,6 @@ jobs:
 
             -   name: Install SQLite 3
                 run: |
-                    sudo apt-get update
                     sudo apt-get install sqlite3
 
             -   name: Setup PHP

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,44 +1,49 @@
 name: run-tests
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
-    test:
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: true
-            matrix:
-                os: [ubuntu-latest]
-                php: [8.0]
-                laravel: [8.*, 7.*]
-                dependency-version: [prefer-lowest, prefer-stable]
-                include:
-                    -   laravel: 8.*
-                        testbench: 6.*
-                    -   laravel: 7.*
-                        testbench: 5.*
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ ubuntu-latest ]
+        php: [ 8.0 ]
+        laravel: [ 8.*, 7.* ]
+        dependency-version: [ prefer-lowest, prefer-stable ]
+        include:
+          - laravel: 8.*
+            testbench: 6.*
+          - laravel: 7.*
+            testbench: 5.*
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
-        steps:
-            -   name: Checkout code
-                uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-            -   name: Install SQLite 3
-                run: |
-                    sudo apt-get install sqlite3
+      - name: Install SQLite 3
+        run: |
+          sudo apt-get install sqlite3
 
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: ${{ matrix.php }}
-                    extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
-                    coverage: none
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
 
-            -   name: Install dependencies
-                run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+      - name: Setup problem matchers
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            -   name: Execute tests
-                run: vendor/bin/phpunit
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+      - name: Execute tests
+        run: vendor/bin/phpunit --no-coverage

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,16 +9,14 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0, 7.4]
-                laravel: [8.*, 6.*, 7.*]
+                php: [8.0]
+                laravel: [8.*, 7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 8.*
                         testbench: 6.*
                     -   laravel: 7.*
                         testbench: 5.*
-                    -   laravel: 6.*
-                        testbench: 4.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
+.idea
+.php_cs
+.php_cs.cache
+.phpunit.result.cache
 build
 composer.lock
+coverage
 docs
+phpunit.xml
+psalm.xml
+testbench.yaml
 vendor
-.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -29,9 +29,15 @@ return PhpCsFixer\Config::create()
         ],
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_var_without_name' => true,
+        'class_attributes_separation' => [
+            'elements' => [
+                'method',
+            ],
+        ],
         'method_argument_space' => [
             'on_multiline' => 'ensure_fully_multiline',
             'keep_multiple_spaces_after_comma' => true,
-        ]
+        ],
+        'single_trait_insert_per_statement' => true,
     ])
     ->setFinder($finder);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `laravel-db-snapshots` will be documented in this file
 
+## 2.0.0 - unreleased
+
+- require PHP 8+
+- drop support for PHP 7
+- drop support for Laravel 6
+- use PHP 8 syntax
+- implement `spatie/laravel-package-tools`
 
 ## 1.7.1 - 2020-12-02
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 
 ## Installation
 
+> For PHP 7.x and/or Laravel 6.x, use v1.x of this package.
+
 You can install the package via Composer:
 
-``` bash
+```bash
 composer require spatie/laravel-db-snapshots
 ```
 

--- a/README.md
+++ b/README.md
@@ -181,23 +181,23 @@ There are several events fired which can be used to perform some logic of your o
 - `Spatie\DbSnapshots\Events\DeletingSnapshot`: will be fired before a snapshot is deleted
 - `Spatie\DbSnapshots\Events\DeletedSnapshot`: will be fired after a snapshot has been deleted
 
-## Changelog
-
-Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
-
 ## Testing
 
-``` bash
+```bash
 composer test
 ```
 
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
+
 ## Contributing
 
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
 
-## Security
+## Security Vulnerabilities
 
-If you discover any security related issues, please email freek@spatie.be instead of using the issue tracker.
+Please review [our security policy](../../security/policy) on how to report security vulnerabilities.
 
 ## Credits
 

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "php": "^8.0",
+        "illuminate/support": "^7.0|^8.0",
         "league/flysystem": "^1.0.41",
-        "spatie/db-dumper": "^2.11",
-        "spatie/temporary-directory": "^1.1"
+        "spatie/db-dumper": "^3.0",
+        "spatie/temporary-directory": "^2.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "^9.1|^9.3"
+        "orchestra/testbench": "^5.0|^6.0",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "illuminate/support": "^7.0|^8.0",
         "league/flysystem": "^1.0.41",
         "spatie/db-dumper": "^3.0",
+        "spatie/laravel-package-tools": "^1.6",
         "spatie/temporary-directory": "^2.0"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    executionOrder="random"
+    failOnWarning="true"
+    failOnRisky="true"
+    failOnEmptyTestSuite="true"
+    beStrictAboutOutputDuringTests="true"
+    verbose="true"
+>
     <testsuites>
-        <testsuite name="Spatie Test Suite">
+        <testsuite name="VendorName Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
 </phpunit>

--- a/src/Commands/Cleanup.php
+++ b/src/Commands/Cleanup.php
@@ -23,8 +23,6 @@ class Cleanup extends Command
             return;
         }
 
-        $snapshots->splice($keep)->each(function ($snapshot) {
-            $snapshot->delete();
-        });
+        $snapshots->splice($keep)->each(fn ($snapshot) => $snapshot->delete());
     }
 }

--- a/src/Commands/Concerns/AsksForSnapshotName.php
+++ b/src/Commands/Concerns/AsksForSnapshotName.php
@@ -11,9 +11,8 @@ trait AsksForSnapshotName
     {
         $snapShots = app(SnapshotRepository::class)->getAll();
 
-        $names = $snapShots->map(function (Snapshot $snapshot) {
-            return $snapshot->name;
-        })->values()->toArray();
+        $names = $snapShots->map(fn (Snapshot $snapshot) =>$snapshot->name)
+            ->values()->toArray();
 
         return $this->choice('Which snapshot?', $names, 0);
     }

--- a/src/Commands/Create.php
+++ b/src/Commands/Create.php
@@ -21,7 +21,7 @@ class Create extends Command
             ?: config('db-snapshots.default_connection')
             ?? config('database.default');
 
-        $snapshotName = $this->argument('name') ?: Carbon::now()->format('Y-m-d_H-i-s');
+        $snapshotName = $this->argument('name') ?? Carbon::now()->format('Y-m-d_H-i-s');
 
         $compress = $this->option('compress') || config('db-snapshots.compress', false);
 

--- a/src/Commands/Delete.php
+++ b/src/Commands/Delete.php
@@ -16,8 +16,6 @@ class Delete extends Command
 
     public function handle()
     {
-        $snapShots = app(SnapshotRepository::class)->getAll();
-
         if (app(SnapshotRepository::class)->getAll()->isEmpty()) {
             $this->warn('No snapshots found. Run `snapshot:create` to create snapshots.');
 

--- a/src/DbDumperFactory.php
+++ b/src/DbDumperFactory.php
@@ -68,13 +68,6 @@ class DbDumperFactory
         throw CannotCreateDbDumper::unsupportedDriver($driver);
     }
 
-    /**
-     * @param array $dumpConfiguration
-     *
-     * @param $dbDumper
-     *
-     * @return mixed
-     */
     protected static function processExtraDumpParameters(array $dumpConfiguration, $dbDumper): DbDumper
     {
         collect($dumpConfiguration)->each(function ($configValue, $configName) use ($dbDumper) {
@@ -91,14 +84,7 @@ class DbDumperFactory
         return $dbDumper;
     }
 
-    /**
-     * @param \Spatie\DbDumper\DbDumper $dbDumper
-     * @param string $methodName
-     * @param string|array|null $methodValue
-     *
-     * @return \Spatie\DbDumper\DbDumper
-     */
-    protected static function callMethodOnDumper(DbDumper $dbDumper, string $methodName, $methodValue = null): DbDumper
+    protected static function callMethodOnDumper(DbDumper $dbDumper, string $methodName, string | array | null $methodValue = null): DbDumper
     {
         if (! $methodValue) {
             $dbDumper->$methodName();
@@ -114,8 +100,6 @@ class DbDumperFactory
     protected static function determineValidMethodName(DbDumper $dbDumper, string $methodName): string
     {
         return collect([$methodName, 'set'.ucfirst($methodName)])
-            ->first(function (string $methodName) use ($dbDumper) {
-                return method_exists($dbDumper, $methodName);
-            }, '');
+            ->first(fn (string $methodName) => method_exists($dbDumper, $methodName), '');
     }
 }

--- a/src/DbSnapshotsServiceProvider.php
+++ b/src/DbSnapshotsServiceProvider.php
@@ -3,23 +3,32 @@
 namespace Spatie\DbSnapshots;
 
 use Illuminate\Contracts\Filesystem\Factory;
-use Illuminate\Support\ServiceProvider;
 use Spatie\DbSnapshots\Commands\Cleanup;
 use Spatie\DbSnapshots\Commands\Create;
 use Spatie\DbSnapshots\Commands\Delete;
 use Spatie\DbSnapshots\Commands\ListSnapshots;
 use Spatie\DbSnapshots\Commands\Load;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\LaravelPackageTools\Package;
 
-class DbSnapshotsServiceProvider extends ServiceProvider
+class DbSnapshotsServiceProvider extends PackageServiceProvider
 {
-    public function boot()
+    public function configurePackage(Package $package): void
     {
-        if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__.'/../config/db-snapshots.php' => config_path('db-snapshots.php'),
-            ], 'config');
-        }
+        $package
+            ->name('laravel-db-snapshots')
+            ->hasConfigFile()
+            ->hasCommands([
+                'command.snapshot:create',
+                'command.snapshot:load',
+                'command.snapshot:delete',
+                'command.snapshot:list',
+                'command.snapshot:cleanup',
+            ]);
+    }
 
+    public function bootingPackage()
+    {
         $this->app->bind(SnapshotRepository::class, function () {
             $diskName = config('db-snapshots.disk');
 
@@ -33,18 +42,5 @@ class DbSnapshotsServiceProvider extends ServiceProvider
         $this->app->bind('command.snapshot:delete', Delete::class);
         $this->app->bind('command.snapshot:list', ListSnapshots::class);
         $this->app->bind('command.snapshot:cleanup', Cleanup::class);
-
-        $this->commands([
-            'command.snapshot:create',
-            'command.snapshot:load',
-            'command.snapshot:delete',
-            'command.snapshot:list',
-            'command.snapshot:cleanup',
-        ]);
-    }
-
-    public function register()
-    {
-        $this->mergeConfigFrom(__DIR__.'/../config/db-snapshots.php', 'db-snapshots');
     }
 }

--- a/src/Events/CreatedSnapshot.php
+++ b/src/Events/CreatedSnapshot.php
@@ -6,10 +6,9 @@ use Spatie\DbSnapshots\Snapshot;
 
 class CreatedSnapshot
 {
-    public Snapshot $snapshot;
-
-    public function __construct(Snapshot $snapshot)
-    {
-        $this->snapshot = $snapshot;
+    public function __construct(
+        public Snapshot $snapshot
+    ) {
+        //
     }
 }

--- a/src/Events/CreatingSnapshot.php
+++ b/src/Events/CreatingSnapshot.php
@@ -6,18 +6,11 @@ use Illuminate\Filesystem\FilesystemAdapter;
 
 class CreatingSnapshot
 {
-    public string $fileName;
-
-    public FilesystemAdapter $disk;
-
-    public string $connectionName;
-
-    public function __construct(string $fileName, FilesystemAdapter $disk, string $connectionName)
-    {
-        $this->fileName = $fileName;
-
-        $this->disk = $disk;
-
-        $this->connectionName = $connectionName;
+    public function __construct(
+        public string $fileName,
+        public FilesystemAdapter $disk,
+        public string $connectionName,
+    ) {
+        //
     }
 }

--- a/src/Events/DeletedSnapshot.php
+++ b/src/Events/DeletedSnapshot.php
@@ -6,14 +6,10 @@ use Illuminate\Filesystem\FilesystemAdapter;
 
 class DeletedSnapshot
 {
-    public string $fileName;
-
-    public FilesystemAdapter $disk;
-
-    public function __construct(string $fileName, FilesystemAdapter $disk)
-    {
-        $this->fileName = $fileName;
-
-        $this->disk = $disk;
+    public function __construct(
+        public string $fileName,
+        public FilesystemAdapter $disk,
+    ) {
+        //
     }
 }

--- a/src/Events/DeletingSnapshot.php
+++ b/src/Events/DeletingSnapshot.php
@@ -6,10 +6,9 @@ use Spatie\DbSnapshots\Snapshot;
 
 class DeletingSnapshot
 {
-    public Snapshot $snapshot;
-
-    public function __construct(Snapshot $snapshot)
-    {
-        $this->snapshot = $snapshot;
+    public function __construct(
+        public Snapshot $snapshot,
+    ) {
+        //
     }
 }

--- a/src/Events/LoadedSnapshot.php
+++ b/src/Events/LoadedSnapshot.php
@@ -6,10 +6,9 @@ use Spatie\DbSnapshots\Snapshot;
 
 class LoadedSnapshot
 {
-    public Snapshot $snapshot;
-
-    public function __construct(Snapshot $snapshot)
-    {
-        $this->snapshot = $snapshot;
+    public function __construct(
+        public Snapshot $snapshot,
+    ) {
+        //
     }
 }

--- a/src/Events/LoadingSnapshot.php
+++ b/src/Events/LoadingSnapshot.php
@@ -6,10 +6,9 @@ use Spatie\DbSnapshots\Snapshot;
 
 class LoadingSnapshot
 {
-    public Snapshot $snapshot;
-
-    public function __construct(Snapshot $snapshot)
-    {
-        $this->snapshot = $snapshot;
+    public function __construct(
+        public Snapshot $snapshot,
+    ) {
+        //
     }
 }

--- a/src/Exceptions/CannotCreateDbDumper.php
+++ b/src/Exceptions/CannotCreateDbDumper.php
@@ -6,12 +6,12 @@ use Exception;
 
 class CannotCreateDbDumper extends Exception
 {
-    public static function unsupportedDriver(string $driver): self
+    public static function unsupportedDriver(string $driver): static
     {
         return new static("Cannot create a dumper for db driver `{$driver}`. Use `mysql`, `pgsql` or `sqlite`.");
     }
 
-    public static function connectionDoesNotExist(string $connectionName): self
+    public static function connectionDoesNotExist(string $connectionName): static
     {
         return new static("Cannot create a dumper. Connection `{$connectionName}` does not exist.");
     }

--- a/src/Exceptions/CannotCreateDisk.php
+++ b/src/Exceptions/CannotCreateDisk.php
@@ -6,7 +6,7 @@ use Exception;
 
 class CannotCreateDisk extends Exception
 {
-    public static function diskNotDefined(string $diskName): self
+    public static function diskNotDefined(string $diskName): static
     {
         $disks = config('filesystems.disks', null);
 

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -36,7 +36,7 @@ class Snapshot
         $this->name = pathinfo($fileName, PATHINFO_FILENAME);
     }
 
-    public function load(string $connectionName = null)
+    public function load(string $connectionName = null): void
     {
         event(new LoadingSnapshot($this));
 
@@ -57,7 +57,7 @@ class Snapshot
         event(new LoadedSnapshot($this));
     }
 
-    public function delete()
+    public function delete(): void
     {
         event(new DeletingSnapshot($this));
 

--- a/src/SnapshotFactory.php
+++ b/src/SnapshotFactory.php
@@ -13,15 +13,11 @@ use Spatie\TemporaryDirectory\TemporaryDirectory;
 
 class SnapshotFactory
 {
-    protected DbDumperFactory $dumperFactory;
-
-    protected Factory $filesystemFactory;
-
-    public function __construct(DbDumperFactory $dumperFactory, Factory $filesystemFactory)
-    {
-        $this->dumperFactory = $dumperFactory;
-
-        $this->filesystemFactory = $filesystemFactory;
+    public function __construct(
+        protected DbDumperFactory $dumperFactory,
+        protected Factory $filesystemFactory,
+    ) {
+        //
     }
 
     public function create(string $snapshotName, string $diskName, string $connectionName, bool $compress = false): Snapshot
@@ -66,7 +62,7 @@ class SnapshotFactory
         return $factory::createForConnection($connectionName);
     }
 
-    protected function createDump(string $connectionName, string $fileName, FilesystemAdapter $disk, bool $compress = false)
+    protected function createDump(string $connectionName, string $fileName, FilesystemAdapter $disk, bool $compress = false): void
     {
         $directory = (new TemporaryDirectory(config('db-snapshots.temporary_directory_path')))->create();
 

--- a/src/SnapshotRepository.php
+++ b/src/SnapshotRepository.php
@@ -7,11 +7,10 @@ use Illuminate\Support\Collection;
 
 class SnapshotRepository
 {
-    protected Disk $disk;
-
-    public function __construct(Disk $disk)
-    {
-        $this->disk = $disk;
+    public function __construct(
+        protected Disk $disk,
+    ) {
+        //
     }
 
     public function getAll(): Collection
@@ -26,18 +25,12 @@ class SnapshotRepository
 
                 return pathinfo($fileName, PATHINFO_EXTENSION) === 'sql';
             })
-            ->map(function (string $fileName) {
-                return new Snapshot($this->disk, $fileName);
-            })
-            ->sortByDesc(function (Snapshot $snapshot) {
-                return $snapshot->createdAt()->toDateTimeString();
-            });
+            ->map(fn (string $fileName) => new Snapshot($this->disk, $fileName))
+            ->sortByDesc(fn (Snapshot $snapshot) => $snapshot->createdAt()->toDateTimeString());
     }
 
     public function findByName(string $name)
     {
-        return $this->getAll()->first(function (Snapshot $snapshot) use ($name) {
-            return $snapshot->name === $name;
-        });
+        return $this->getAll()->first(fn (Snapshot $snapshot) => $snapshot->name === $name);
     }
 }


### PR DESCRIPTION
This PR adds a new major version, v2.0.0.

Specifically, it:

- Removes support for all PHP 7.x versions.
- Requires PHP 8.0+.
- Uses PHP 8 syntax where possible.
- Removes unnecessary PHP docblocks per Spatie's guidelines.
- Removes Laravel v6 support.
- Implements `spatie/laravel-package-tools`.
- Uses the latest PHP 8 version of spatie packages where possible.
- Adds/updates various dot/config files from `spatie/package-skeleton-laravel`.
- Adds a note to the readme on what package version to use for Laravel 6 or PHP 7.
- _Updates the changelog - release date needs to be updated, currently is "unreleased"._
