### PR TITLE
Fix undefined array key error in `SnapshotRepository::getAll()`

### DIFF
--- a/src/SnapshotRepository.php
+++ b/src/SnapshotRepository.php
@@ -19,7 +19,10 @@ class SnapshotRepository
             ->filter(function (string $fileName) {
                 $pathinfo = pathinfo($fileName);
 
-                if ($pathinfo['extension'] === 'gz') {
+                if (
+                    array_key_exists('extension', $pathinfo)
+                    && $pathinfo['extension'] === 'gz'
+                ) {
                     $fileName = $pathinfo['filename'];
                 }
 

--- a/src/SnapshotRepository.php
+++ b/src/SnapshotRepository.php
@@ -19,10 +19,7 @@ class SnapshotRepository
             ->filter(function (string $fileName) {
                 $pathinfo = pathinfo($fileName);
 
-                if (
-                    array_key_exists('extension', $pathinfo)
-                    && $pathinfo['extension'] === 'gz'
-                ) {
+                if (($pathinfo['extension'] ?? null) === 'gz') {
                     $fileName = $pathinfo['filename'];
                 }
 


### PR DESCRIPTION
Simple fix for #117 — don't try to access `extension` of file's `pathinfo` unless it exists