### PR TITLE
add --exclude to the create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,18 +84,18 @@ This is the content of the published file:
 ```php
 return [
 
-    /**
+    /*
      * The name of the disk on which the snapshots are stored.
      */
     'disk' => 'snapshots',
 
-    /**
+    /*
      * The connection to be used to create snapshots. Set this to null
-     * to use the default configured in `config/database.php`
+     * to use the default configured in `config/databases.php`
      */
     'default_connection' => null,
 
-    /**
+    /*
      * The directory where temporary files will be stored.
      */
     'temporary_directory_path' => storage_path('app/laravel-db-snapshots/temp'),
@@ -111,7 +111,15 @@ return [
      * Default: `null`
      */
     'tables' => null,
+
+    /*
+     * All tables will be included in the snapshot expect this tables. Set to `null` to include all tables.
+     *
+     * Default: `null`
+     */
+    'exclude' => null,
 ];
+
 ```
 
 ## Usage
@@ -136,6 +144,15 @@ Maybe you only want to snapshot a couple of tables. You can do this by passing t
 php artisan snapshot:create --table=posts,users
 php artisan snapshot:create --table=posts --table=users
 ```
+
+You may want to exclude some tables from snapshot. You can do this by passing the `--exclude` multiple times or as a comma separated list:
+```bash
+# create snapshot from all tables exclude the users and posts
+php artisan snapshot:create --exclude=posts,users
+php artisan snapshot:create --exclude=posts --exclude=users
+```
+> Note: if you pass `--table` and `--exclude` in the same time it will use `--table` to create the snapshot and it's ignore the `--exclude`
+> Note: this feature is not supported in `sqlite` DB.
 
 When creating snapshots, you can optionally create compressed snapshots.  To do this either pass the `--compress` option on the command line, or set the `db-snapshots.compress` configuration option to `true`:
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ php artisan snapshot:create --exclude=posts,users
 php artisan snapshot:create --exclude=posts --exclude=users
 ```
 > Note: if you pass `--table` and `--exclude` in the same time it will use `--table` to create the snapshot and it's ignore the `--exclude`
-> Note: this feature is not supported in `sqlite` DB.
 
 When creating snapshots, you can optionally create compressed snapshots.  To do this either pass the `--compress` option on the command line, or set the `db-snapshots.compress` configuration option to `true`:
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.0",
         "illuminate/support": "^7.0|^8.0|^9.0",
         "league/flysystem": "^1.0.41|^2.0|^3.0",
-        "spatie/db-dumper": "^3.1",
+        "spatie/db-dumper": "^3.3",
         "spatie/laravel-package-tools": "^1.6",
         "spatie/temporary-directory": "^2.0"
     },

--- a/config/db-snapshots.php
+++ b/config/db-snapshots.php
@@ -29,4 +29,11 @@ return [
      * Default: `null`
      */
     'tables' => null,
+
+    /*
+     * All tables will be included in the snapshot expect this tables. Set to `null` to include all tables.
+     *
+     * Default: `null`
+     */
+    'exclude' => null,
 ];

--- a/src/Commands/Create.php
+++ b/src/Commands/Create.php
@@ -9,7 +9,7 @@ use Spatie\DbSnapshots\SnapshotFactory;
 
 class Create extends Command
 {
-    protected $signature = 'snapshot:create {name?} {--connection=} {--compress} {--table=*}';
+    protected $signature = 'snapshot:create {name?} {--connection=} {--compress} {--table=*} {--exclude=*}';
 
     protected $description = 'Create a new snapshot.';
 
@@ -28,12 +28,19 @@ class Create extends Command
         $tables = $this->option('table') ?: config('db-snapshots.tables', null);
         $tables = is_string($tables) ? explode(',', $tables) : $tables;
 
+        if (is_null($tables)){
+            $exclude = $this->option('exclude') ?: config('db-snapshots.exclude', null);
+            $exclude = is_string($exclude) ? explode(',', $exclude) : $exclude;
+        }
+
+
         $snapshot = app(SnapshotFactory::class)->create(
             $snapshotName,
             config('db-snapshots.disk'),
             $connectionName,
             $compress,
-            $tables
+            $tables,
+            $exclude??null
         );
 
         $size = Format::humanReadableSize($snapshot->size());

--- a/src/Commands/Create.php
+++ b/src/Commands/Create.php
@@ -28,9 +28,11 @@ class Create extends Command
         $tables = $this->option('table') ?: config('db-snapshots.tables', null);
         $tables = is_string($tables) ? explode(',', $tables) : $tables;
 
-        if (is_null($tables)){
+        if (is_null($tables)) {
             $exclude = $this->option('exclude') ?: config('db-snapshots.exclude', null);
             $exclude = is_string($exclude) ? explode(',', $exclude) : $exclude;
+        } else {
+            $exclude = null;
         }
 
 
@@ -40,7 +42,7 @@ class Create extends Command
             $connectionName,
             $compress,
             $tables,
-            $exclude??null
+            $exclude
         );
 
         $size = Format::humanReadableSize($snapshot->size());

--- a/src/Events/CreatingSnapshot.php
+++ b/src/Events/CreatingSnapshot.php
@@ -10,7 +10,8 @@ class CreatingSnapshot
         public string $fileName,
         public FilesystemAdapter $disk,
         public string $connectionName,
-        public ?array $tables = null
+        public ?array $tables = null,
+        public ?array $exclude = null
     ) {
         //
     }

--- a/src/SnapshotFactory.php
+++ b/src/SnapshotFactory.php
@@ -35,7 +35,8 @@ class SnapshotFactory
             $fileName,
             $disk,
             $connectionName,
-            $tables
+            $tables,
+            $exclude
         ));
 
         $this->createDump($connectionName, $fileName, $disk, $compress, $tables, $exclude);

--- a/src/SnapshotFactory.php
+++ b/src/SnapshotFactory.php
@@ -20,11 +20,11 @@ class SnapshotFactory
         //
     }
 
-    public function create(string $snapshotName, string $diskName, string $connectionName, bool $compress = false, ?array $tables = null): Snapshot
+    public function create(string $snapshotName, string $diskName, string $connectionName, bool $compress = false, ?array $tables = null, ?array $exclude = null): Snapshot
     {
         $disk = $this->getDisk($diskName);
 
-        $fileName = $snapshotName.'.sql';
+        $fileName = $snapshotName . '.sql';
         $fileName = pathinfo($fileName, PATHINFO_BASENAME);
 
         if ($compress) {
@@ -38,7 +38,7 @@ class SnapshotFactory
             $tables
         ));
 
-        $this->createDump($connectionName, $fileName, $disk, $compress, $tables);
+        $this->createDump($connectionName, $fileName, $disk, $compress, $tables, $exclude);
 
         $snapshot = new Snapshot($disk, $fileName);
 
@@ -63,7 +63,7 @@ class SnapshotFactory
         return $factory::createForConnection($connectionName);
     }
 
-    protected function createDump(string $connectionName, string $fileName, FilesystemAdapter $disk, bool $compress = false, ?array $tables = null): void
+    protected function createDump(string $connectionName, string $fileName, FilesystemAdapter $disk, bool $compress = false, ?array $tables = null, ?array $exclude = null): void
     {
         $directory = (new TemporaryDirectory(config('db-snapshots.temporary_directory_path')))->create();
 
@@ -77,6 +77,10 @@ class SnapshotFactory
 
         if (is_array($tables)) {
             $dbDumper->includeTables($tables);
+        }
+
+        if (is_array($exclude)) {
+            $dbDumper->excludeTables($exclude);
         }
 
         $dbDumper->dumpToFile($dumpPath);

--- a/tests/Commands/CreateTest.php
+++ b/tests/Commands/CreateTest.php
@@ -91,4 +91,41 @@ class CreateTest extends TestCase
         $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "posts"/');
         $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
     }
+    /** @test */
+    public function it_can_create_a_snapshot_without_excluded_tables_specified_in_the_command_options()
+    {
+        Artisan::call('snapshot:create', ['--exclude' => ['users', 'posts']]);
+
+        $fileName = Carbon::now()->format('Y-m-d_H-i-s') . '.sql';
+
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "users"/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "posts"/');
+        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
+    }
+
+    /** @test */
+    public function it_can_create_a_snapshot_without_excluded_tables_specified_in_the_command_options_as_a_string()
+    {
+        Artisan::call('snapshot:create', ['--exclude' => 'users,posts']);
+
+        $fileName = Carbon::now()->format('Y-m-d_H-i-s') . '.sql';
+
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "users"/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "posts"/');
+        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
+    }
+
+    /** @test */
+    public function it_can_create_a_snapshot_without_excluded_tables_specified_in_the_config()
+    {
+        $this->app['config']->set('db-snapshots.exclude', ['users', 'posts']);
+
+        Artisan::call('snapshot:create');
+
+        $fileName = Carbon::now()->format('Y-m-d_H-i-s') . '.sql';
+
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "users"/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "posts"/');
+        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
+    }
 }

--- a/tests/Commands/CreateTest.php
+++ b/tests/Commands/CreateTest.php
@@ -95,47 +95,38 @@ class CreateTest extends TestCase
     /** @test */
     public function it_can_create_a_snapshot_without_excluded_tables_specified_in_the_command_options()
     {
-        if ($this->app['config']['database']['connections']['testing']['driver'] === 'sqlite') {
-            $this->markTestSkipped('sqlite not supporting exclude functionality');
-        }
         Artisan::call('snapshot:create', ['--exclude' => ['users', 'posts']]);
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s') . '.sql';
 
-        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE `users`/');
-        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE `posts`/');
-        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE `models`/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "users"/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "posts"/');
+        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
     }
 
     /** @test */
     public function it_can_create_a_snapshot_without_excluded_tables_specified_in_the_command_options_as_a_string()
     {
-        if ($this->app['config']['database']['connections']['testing']['driver'] === 'sqlite') {
-            $this->markTestSkipped('sqlite not supporting exclude functionality');
-        }
         Artisan::call('snapshot:create', ['--exclude' => 'users,posts']);
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s') . '.sql';
 
-        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE `users`/');
-        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE `posts`/');
-        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE `models`/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "users"/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "posts"/');
+        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
     }
 
     /** @test */
     public function it_can_create_a_snapshot_without_excluded_tables_specified_in_the_config()
     {
-        if ($this->app['config']['database']['connections']['testing']['driver'] === 'sqlite') {
-            $this->markTestSkipped('sqlite not supporting exclude functionality');
-        }
         $this->app['config']->set('db-snapshots.exclude', ['users', 'posts']);
 
         Artisan::call('snapshot:create');
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s') . '.sql';
 
-        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE `users`/');
-        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE `posts`/');
-        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE `models`/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "users"/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "posts"/');
+        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
     }
 }

--- a/tests/Commands/CreateTest.php
+++ b/tests/Commands/CreateTest.php
@@ -91,41 +91,51 @@ class CreateTest extends TestCase
         $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "posts"/');
         $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
     }
+
     /** @test */
     public function it_can_create_a_snapshot_without_excluded_tables_specified_in_the_command_options()
     {
+        if ($this->app['config']['database']['connections']['testing']['driver'] === 'sqlite') {
+            $this->markTestSkipped('sqlite not supporting exclude functionality');
+        }
         Artisan::call('snapshot:create', ['--exclude' => ['users', 'posts']]);
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s') . '.sql';
 
-        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "users"/');
-        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "posts"/');
-        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE `users`/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE `posts`/');
+        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE `models`/');
     }
 
     /** @test */
     public function it_can_create_a_snapshot_without_excluded_tables_specified_in_the_command_options_as_a_string()
     {
+        if ($this->app['config']['database']['connections']['testing']['driver'] === 'sqlite') {
+            $this->markTestSkipped('sqlite not supporting exclude functionality');
+        }
         Artisan::call('snapshot:create', ['--exclude' => 'users,posts']);
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s') . '.sql';
 
-        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "users"/');
-        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "posts"/');
-        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE `users`/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE `posts`/');
+        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE `models`/');
     }
 
     /** @test */
     public function it_can_create_a_snapshot_without_excluded_tables_specified_in_the_config()
     {
+        if ($this->app['config']['database']['connections']['testing']['driver'] === 'sqlite') {
+            $this->markTestSkipped('sqlite not supporting exclude functionality');
+        }
         $this->app['config']->set('db-snapshots.exclude', ['users', 'posts']);
 
         Artisan::call('snapshot:create');
 
         $fileName = Carbon::now()->format('Y-m-d_H-i-s') . '.sql';
 
-        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "users"/');
-        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "posts"/');
-        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE `users`/');
+        $this->assertFileOnDiskFailsRegex($fileName, '/CREATE TABLE `posts`/');
+        $this->assertFileOnDiskPassesRegex($fileName, '/CREATE TABLE `models`/');
     }
 }

--- a/tests/Events/CreatingSnapshotTest.php
+++ b/tests/Events/CreatingSnapshotTest.php
@@ -20,4 +20,16 @@ class CreatingSnapshotTest extends TestCase
             return $event->fileName === 'my-snapshot.sql';
         });
     }
+
+    /** @test */
+    public function creating_a_snapshot_with_exclude_will_pass_excluded_tables()
+    {
+        Event::fake();
+
+        Artisan::call('snapshot:create', ['name' => 'my-snapshot', '--exclude' => ['tb1', 'tb2']]);
+
+        Event::assertDispatched(CreatingSnapshot::class, function (CreatingSnapshot $event) {
+            return ($event->fileName === 'my-snapshot.sql') && $event->exclude === ['tb1', 'tb2'];
+        });
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -45,12 +45,9 @@ abstract class TestCase extends Orchestra
     {
         $app['config']->set('database.default', 'testing');
         $app['config']->set('database.connections.testing', [
-            'driver' => 'mysql',
-            'host'=>'127.0.0.1',
-            'port'=>'3306',
-            'database'=>'test',
-            'username'=>'root',
-            'password'=>'09158585889'
+            'driver' => 'sqlite',
+            'database' => __DIR__.'/temp/database.sqlite',
+            'prefix' => '',
         ]);
 
         $app['config']->set('filesystems.disks.snapshots', [
@@ -79,7 +76,6 @@ abstract class TestCase extends Orchestra
 
     protected function setupDatabase()
     {
-        Artisan::call('db:wipe');
         $databasePath = __DIR__.'/temp/database.sqlite';
 
         if (file_exists($databasePath)) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -45,9 +45,12 @@ abstract class TestCase extends Orchestra
     {
         $app['config']->set('database.default', 'testing');
         $app['config']->set('database.connections.testing', [
-            'driver' => 'sqlite',
-            'database' => __DIR__.'/temp/database.sqlite',
-            'prefix' => '',
+            'driver' => 'mysql',
+            'host'=>'127.0.0.1',
+            'port'=>'3306',
+            'database'=>'test',
+            'username'=>'root',
+            'password'=>'09158585889'
         ]);
 
         $app['config']->set('filesystems.disks.snapshots', [
@@ -76,6 +79,7 @@ abstract class TestCase extends Orchestra
 
     protected function setupDatabase()
     {
+        Artisan::call('db:wipe');
         $databasePath = __DIR__.'/temp/database.sqlite';
 
         if (file_exists($databasePath)) {


### PR DESCRIPTION
with this PR users can exclude tables that they want instead of passing each table name in `--table` option.

- [x] update create events to support excluded tables
- [x] https://github.com/spatie/db-dumper/pull/177