### PR TITLE
Support connect_via_database

### DIFF
--- a/src/DbDumperFactory.php
+++ b/src/DbDumperFactory.php
@@ -32,9 +32,11 @@ class DbDumperFactory
             $fallback
         );
 
+        $dbName = $dbConfig['connect_via_database'] ?? $dbConfig['database'];
+
         $dbDumper = static::forDriver($dbConfig['driver'])
             ->setHost($dbHost ?? '')
-            ->setDbName($dbConfig['database'])
+            ->setDbName($dbName)
             ->setUserName($dbConfig['username'] ?? '')
             ->setPassword($dbConfig['password'] ?? '');
 

--- a/tests/DbDumperFactoryTest.php
+++ b/tests/DbDumperFactoryTest.php
@@ -72,6 +72,25 @@ class DbDumperFactoryTest extends TestCase
     }
 
     /** @test */
+    public function it_will_use_connect_via_database_when_one_is_defined()
+    {
+        $dbConfig = [
+            'driver' => 'pgsql',
+            'connect_via_database' => 'connection_pool',
+            'username' => 'root',
+            'password' => 'myPassword',
+            'database' => 'myDb',
+            'dump' => ['add_extra_option' => '--extra-option=value'],
+        ];
+
+        $this->app['config']->set('database.connections.pgsql', $dbConfig);
+
+        $dumper = DbDumperFactory::createForConnection('pgsql');
+
+        $this->assertEquals('connection_pool', $dumper->getDbName());
+    }
+
+    /** @test */
     public function it_will_throw_an_exception_when_creating_an_unknown_type_of_dumper()
     {
         $this->expectException(CannotCreateDbDumper::class);


### PR DESCRIPTION
[PostgreSQL](https://www.postgresql.org/) users often use a connection pool like [PgBouncer](https://www.pgbouncer.org/).

This requires a `connect_via_database` database config to work properly.

Laravel added support for this: https://github.com/illuminate/database/commit/459df89ff6799c5bbcf2bfd0c56159abcebc33dd

This merge request adds support for the optional `connect_via_database` config setting.