### PR TITLE
Support db config via database url

### DIFF
--- a/src/DbDumperFactory.php
+++ b/src/DbDumperFactory.php
@@ -4,6 +4,7 @@ namespace Spatie\DbSnapshots;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\ConfigurationUrlParser;
 use Spatie\DbDumper\Databases\MySql;
 use Spatie\DbDumper\Databases\PostgreSql;
 use Spatie\DbDumper\Databases\Sqlite;
@@ -18,6 +19,10 @@ class DbDumperFactory
 
         if (is_null($dbConfig)) {
             throw CannotCreateDbDumper::connectionDoesNotExist($connectionName);
+        }
+
+        if (! empty($dbConfig['url'])) {
+            $dbConfig = (new ConfigurationUrlParser)->parseConfiguration($dbConfig);
         }
 
         $fallback = Arr::get(

--- a/tests/DbDumperFactoryTest.php
+++ b/tests/DbDumperFactoryTest.php
@@ -122,3 +122,22 @@ it('can add arbitrary options to the dump command', function () {
 it('adds the inserts option to the pgSQL dump command')
     ->expect(fn () => getDumpCommand('pgsql'))
     ->toContain('--inserts');
+
+it('will use url when one is defined', function () {
+    $dbConfig = [
+        'driver' => 'mysql',
+        'username' => 'root',
+        'password' => 'myPassword',
+        'database' => 'myDb',
+        'host' => '127.0.0.1',
+        'port' => '3306',
+        'url' => 'mysql://otherUser:otherPass@otherHost:3307/otherDb',
+    ];
+
+    $this->app['config']->set('database.connections.mysql', $dbConfig);
+
+    $dumper = DbDumperFactory::createForConnection('mysql');
+
+    expect($dumper->getDbName())->toEqual('otherDb');
+    expect($dumper->getHost())->toEqual('otherHost');
+});


### PR DESCRIPTION
This package currently gets the [database configuration](https://github.com/spatie/laravel-db-snapshots/blob/main/src/DbDumperFactory.php#L17) and looks at the `host`, `database`, `username` and `password` from that to use for dumping.

Since around 5.8 or so Laravel supports defining Database config using the `url` key in the database config array. 

If `url` is set it is used in preference to the discrete values - `laravel/framework` looks at the connection config and if the key `url` is present, and if so it is used **instead** of any configured `host`, `port`, `username`, `password`, `database`. This can be seen here in 9.x:

https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/DatabaseManager.php#L169-L170
https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Console/DbCommand.php#L73-L75

https://github.com/laravel/framework/blob/9.x/src/Illuminate/Support/ConfigurationUrlParser.php#L30

As this package currently is hard coded to look at `host` etc if `url` is set and the default values which are specified in `config/database.php` the "wrong" connection is attempted, and this is inconsistent with how the framework behaves. 

(A workaround is to set the database url values to the config separately but this isn't practical when database url is dynamic e.g. ENV in Docker being set by another part of the orchestration.)

This PR uses the `Illuminate\Support\ConfigurationUrlParser` to set and overwrite the db config if `url` is present, the same way as the `Illuminate\Database\Console\DbCommand` does.
Laravel works the same way in 7.x, 8.x and 9.x - so this should be compatible for all this packages supported versions.

This should be backwards compatible for existing users, unless they are somehow relying on the inconsistent behaviour to access a different set of configuration from their app. 

In the tests I added explicit values so it was clear that the assertions differ and tested the two relevant public properties from  `DbDumperFactory` as due to the way `Illuminate\Support\ConfigurationUrlParser` works if these are set all the other `url` parameters will be set too.