### PR TITLE
Add MariaDB support

### DIFF
--- a/src/DbDumperFactory.php
+++ b/src/DbDumperFactory.php
@@ -55,7 +55,7 @@ class DbDumperFactory
     {
         $driver = strtolower($dbDriver);
 
-        if ($driver === 'mysql') {
+        if (in_array($driver, ['mariadb', 'mysql'])) {
             return new MySql();
         }
 


### PR DESCRIPTION
This should solve:
```
local.ERROR: Cannot create a dumper for db driver `mariadb`. Use `mysql`, `pgsql` or `sqlite`. {"exception":"[object] (Spatie\\DbSnapshots\\Exceptions\\CannotCreateDbDumper(code: 0): Cannot create a dumper for db driver `mariadb`. Use `mysql`, `pgsql` or `sqlite`. at /app/vendor/spatie/laravel-db-snapshots/src/Exceptions/CannotCreateDbDumper.php:11)
```
Since Laravel 11, MariaDB has a dedicated driver.