### PR TITLE
Code health updates

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1]
+        php: [8.4, 8.3, 8.2, 8.1]
         laravel: ['10.*', '11.*']
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,25 +16,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1, 8.0]
-        laravel: ['8.*', '9.*', '10.*', '11.*']
+        php: [8.2, 8.1]
+        laravel: ['10.*', '11.*']
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
-          - laravel: 9.*
-            testbench: 7.*
-          - laravel: 8.*
-            testbench: ^6.23
           - laravel: 11.*
             testbench: 9.*
         exclude:
-          - laravel: 10.*
-            php: 8.0
           - laravel: 11.*
             php: 8.1
-          - laravel: 11.*
-            php: 8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,18 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0",
-        "league/flysystem": "^1.0.41|^2.0|^3.0",
+        "php": "^8.1",
+        "illuminate/support": "^10.0|^11.0",
+        "league/flysystem": "^3.0",
         "spatie/db-dumper": "^3.3",
         "spatie/laravel-package-tools": "^1.6",
         "spatie/temporary-directory": "^2.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0|^9.0",
-        "pestphp/pest-plugin-laravel": "^1.3|^2.3",
-        "phpunit/phpunit": "^9.5|^10.5"
+        "orchestra/testbench": "^8.22.3|^9.0.4",
+        "pestphp/pest-plugin-laravel": "^2.4",
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Commands/Cleanup.php
+++ b/src/Commands/Cleanup.php
@@ -3,6 +3,7 @@
 namespace Spatie\DbSnapshots\Commands;
 
 use Illuminate\Console\Command;
+use Spatie\DbSnapshots\Snapshot;
 use Spatie\DbSnapshots\SnapshotRepository;
 
 class Cleanup extends Command
@@ -23,6 +24,6 @@ class Cleanup extends Command
             return;
         }
 
-        $snapshots->splice($keep)->each(fn ($snapshot) => $snapshot->delete());
+        $snapshots->splice($keep)->each(fn (Snapshot $snapshot) => $snapshot->delete());
     }
 }

--- a/src/Exceptions/CannotCreateDisk.php
+++ b/src/Exceptions/CannotCreateDisk.php
@@ -16,6 +16,6 @@ class CannotCreateDisk extends Exception
 
         $existingDiskNames = implode(', ', array_keys($disks));
 
-        return new static("Cannot create a disk `{$diskName}`. Known disknames are {$existingDiskNames}.");
+        return new static("Cannot create a disk `{$diskName}`. Known disk names are {$existingDiskNames}.");
     }
 }

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -78,7 +78,7 @@ class Snapshot
 
     protected function isASqlComment(string $line): bool
     {
-        return substr($line, 0, 2) === '--';
+        return str_starts_with($line, '--');
     }
 
     protected function shouldIgnoreLine(string $line): bool
@@ -116,14 +116,14 @@ class Snapshot
                         break;
                     }
 
-                    if (substr(trim($statement), -1, 1) === ';') {
+                    if (str_ends_with(trim($statement), ';')) {
                         yield $statement;
                         $statement = '';
                     }
                 }
             }
 
-            if (substr(trim($statement), -1, 1) === ';') {
+            if (str_ends_with(trim($statement), ';')) {
                 yield $statement;
             }
         })->each(function (string $statement) use ($connectionName) {

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -41,7 +41,7 @@ class Snapshot
         $this->name = pathinfo($fileName, PATHINFO_FILENAME);
     }
 
-    public function useStream()
+    public function useStream(): self
     {
         $this->useStream = true;
 
@@ -65,7 +65,7 @@ class Snapshot
         event(new LoadedSnapshot($this));
     }
 
-    protected function loadAsync(?string $connectionName = null)
+    protected function loadAsync(?string $connectionName = null): void
     {
         $dbDumpContents = $this->disk->get($this->fileName);
 
@@ -88,7 +88,7 @@ class Snapshot
         return empty($line) || $this->isASqlComment($line);
     }
 
-    protected function loadStream(?string $connectionName = null)
+    protected function loadStream(?string $connectionName = null): void
     {
         LazyCollection::make(function () {
             $stream = $this->compressionExtension === 'gz'
@@ -150,7 +150,7 @@ class Snapshot
         return Carbon::createFromTimestamp($this->disk->lastModified($this->fileName));
     }
 
-    protected function dropAllCurrentTables()
+    protected function dropAllCurrentTables(): void
     {
         DB::connection(DB::getDefaultConnection())
             ->getSchemaBuilder()

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -48,7 +48,7 @@ class Snapshot
         return $this;
     }
 
-    public function load(string $connectionName = null, bool $dropTables = true): void
+    public function load(?string $connectionName = null, bool $dropTables = true): void
     {
         event(new LoadingSnapshot($this));
 
@@ -65,7 +65,7 @@ class Snapshot
         event(new LoadedSnapshot($this));
     }
 
-    protected function loadAsync(string $connectionName = null)
+    protected function loadAsync(?string $connectionName = null)
     {
         $dbDumpContents = $this->disk->get($this->fileName);
 
@@ -88,7 +88,7 @@ class Snapshot
         return empty($line) || $this->isASqlComment($line);
     }
 
-    protected function loadStream(string $connectionName = null)
+    protected function loadStream(?string $connectionName = null)
     {
         LazyCollection::make(function () {
             $stream = $this->compressionExtension === 'gz'

--- a/src/SnapshotRepository.php
+++ b/src/SnapshotRepository.php
@@ -13,6 +13,9 @@ class SnapshotRepository
         //
     }
 
+    /**
+     * @return Collection<Snapshot>
+     */
     public function getAll(): Collection
     {
         return collect($this->disk->allFiles())
@@ -29,7 +32,7 @@ class SnapshotRepository
             ->sortByDesc(fn (Snapshot $snapshot) => $snapshot->createdAt()->toDateTimeString());
     }
 
-    public function findByName(string $name)
+    public function findByName(string $name): ?Snapshot
     {
         return $this->getAll()->first(fn (Snapshot $snapshot) => $snapshot->name === $name);
     }

--- a/tests/Commands/CreateTest.php
+++ b/tests/Commands/CreateTest.php
@@ -15,7 +15,7 @@ it('can create a snapshot without a specific', function () {
 });
 
 it('can create a snapshot with specific name')
-    ->tap(fn () => Artisan::call('snapshot:create', ['name' => 'test']))
+    ->defer(fn () => Artisan::call('snapshot:create', ['name' => 'test']))
     ->expect('test.sql')
     ->fileOnDiskToPassRegex('/CREATE TABLE(?: IF NOT EXISTS){0,1} "models"/');
 


### PR DESCRIPTION
- Updated old str_* methods to newer PHP 8 str_* methods
- Marked implicitly nullable parameters as explicitly nullable, as implicit nullability is deprecated since PHP 8.4
- Fixed a typo
- Added missing typehints wherever it made sense
- Replaced `tap()` with `defer()` in a test - `tap()` is deprecated, it is essentially an alias for `defer()`