### PR TITLE
Allow spatie/db-dumper v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.2",
         "illuminate/support": "^11.0|^12.0|^13.0",
         "league/flysystem": "^3.0",
-        "spatie/db-dumper": "^3.3",
+        "spatie/db-dumper": "^3.3|^4.0",
         "spatie/laravel-package-tools": "^1.6",
         "spatie/temporary-directory": "^2.0"
     },


### PR DESCRIPTION
## Summary
- Widen the `spatie/db-dumper` constraint from `^3.3` to `^3.3|^4.0`
- No code changes needed since db-dumper v4's API is fully backwards-compatible with how this package uses it

## Why
`spatie/laravel-backup` v9 requires `spatie/db-dumper ^4.0`, making it impossible to install both `laravel-backup` and `laravel-db-snapshots` in the same project without this constraint widening.

## Test plan
- All 51 existing tests pass against db-dumper 4.1.0 without any modifications